### PR TITLE
Improve TLS fragment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 | **Connectivity Testing** | Optional TCP checks measure real latency. | Prioritize servers that actually respond. |
 | **Smart Sorting** | Orders the final list by reachability and speed. | Quickly pick the best server in your VPN client. |
 | **Batch Saving** | Periodically saves intermediate results with `--batch-size`. | Useful on unreliable connections. |
-| **Protocol Filtering** | Use `--fragment` or `--top-n` to trim the output. | Keep only certain protocols or the fastest N entries. |
+| **Protocol Filtering** | Use `--tls-fragment` or `--top-n` to trim the output. | Keep only certain protocols or the fastest N entries. |
+| **Custom Output Dir** | Use `--output-dir` to choose where files are saved. | Organize results anywhere you like. |
+| **Set Test Timeout** | Tune connection checks with `--test-timeout`. | Useful for slow or distant servers. |
 | **Disable Features** | Flags `--no-url-test` and `--no-sort` give full control. | Run fast tests or skip sorting when not needed. |
 
 ## 📖 Table of Contents
@@ -238,7 +240,14 @@ Run `python vpn_merger.py --help` to see all options. Important flags include:
   * `--no-url-test` - skip reachability testing for faster execution.
   * `--no-sort` - keep configs in the order retrieved without sorting.
   * `--top-n N` - keep only the best `N` configs after sorting.
-  * `--fragment TEXT` - only keep configs containing `TEXT`.
+  * `--tls-fragment TEXT` - only keep configs containing this TLS fragment.
+  * `--output-dir DIR` - specify where output files are stored.
+  * `--test-timeout SEC` - adjust connection test timeout.
+
+TLS fragments help obscure the real Server Name Indication (SNI) of each
+connection by splitting the handshake into pieces. This makes it harder for
+filtering systems to detect the destination server, especially when weak SNI
+protections would otherwise expose it.
 
 #### **Adding Your Own Sources**
 

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -93,7 +93,7 @@ class Config:
     batch_size: int
     threshold: int
     top_n: int
-    fragment_filter: Optional[str]
+    tls_fragment: Optional[str]
 
 CONFIG = Config(
     headers={
@@ -123,7 +123,7 @@ CONFIG = Config(
     batch_size=0,
     threshold=0,
     top_n=0,
-    fragment_filter=None
+    tls_fragment=None
 )
 
 # ============================================================================
@@ -985,7 +985,7 @@ class UltimateVPNMerger:
         unique_results: List[ConfigResult] = []
 
         for result in results:
-            if CONFIG.fragment_filter and CONFIG.fragment_filter.lower() not in result.config.lower():
+            if CONFIG.tls_fragment and CONFIG.tls_fragment.lower() not in result.config.lower():
                 continue
             config_hash = self.processor.create_semantic_hash(result.config)
             if config_hash not in seen_hashes:
@@ -1228,8 +1228,12 @@ def main():
                         help="Stop processing after N unique configs (0 = unlimited)")
     parser.add_argument("--top-n", type=int, default=CONFIG.top_n,
                         help="Keep only the N best configs after sorting (0 = all)")
-    parser.add_argument("--fragment", type=str, default=CONFIG.fragment_filter,
-                        help="Only keep configs containing this fragment")
+    parser.add_argument("--tls-fragment", type=str, default=CONFIG.tls_fragment,
+                        help="Only keep configs containing this TLS fragment")
+    parser.add_argument("--output-dir", type=str, default=CONFIG.output_dir,
+                        help="Directory to save output files")
+    parser.add_argument("--test-timeout", type=float, default=CONFIG.test_timeout,
+                        help="TCP connection test timeout in seconds")
     parser.add_argument("--no-url-test", action="store_true",
                         help="Disable server reachability testing")
     parser.add_argument("--no-sort", action="store_true",
@@ -1239,7 +1243,9 @@ def main():
     CONFIG.batch_size = max(0, args.batch_size)
     CONFIG.threshold = max(0, args.threshold)
     CONFIG.top_n = max(0, args.top_n)
-    CONFIG.fragment_filter = args.fragment
+    CONFIG.tls_fragment = args.tls_fragment
+    CONFIG.output_dir = args.output_dir
+    CONFIG.test_timeout = max(0.1, args.test_timeout)
     if args.no_url_test:
         CONFIG.enable_url_testing = False
     if args.no_sort:


### PR DESCRIPTION
## Summary
- rename `--fragment` option to `--tls-fragment`
- support configurable output directory and connection test timeout
- document the new options and explain TLS fragments

## Testing
- `python -m py_compile vpn_merger.py vpn_retester.py`
- `python vpn_merger.py --help` *(fails: ModuleNotFoundError: No module named 'aiodns')*

------
https://chatgpt.com/codex/tasks/task_e_686312b919f083268dd8a4f276342760