### PR TITLE
Fix CLI arg parsing in vpn_merger

### DIFF
--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -1291,7 +1291,9 @@ def main():
                         help="Disable server reachability testing")
     parser.add_argument("--no-sort", action="store_true",
                         help="Disable performance-based sorting")
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        logging.warning("Ignoring unknown arguments: %s", unknown)
 
     CONFIG.batch_size = max(0, args.batch_size)
     CONFIG.threshold = max(0, args.threshold)


### PR DESCRIPTION
## Summary
- handle unknown args in `vpn_merger.py` so Jupyter doesn't crash

## Testing
- `python vpn_merger.py --help | head -n 8`
- `python vpn_merger.py --unknown-arg 2>&1 | head -n 3`
- `python - <<'EOF'
import vpn_merger, sys
sys.argv = ['vpn_merger.py', '-f', 'dummy.json']
try:
    vpn_merger.run_in_jupyter()
    print('no SystemExit')
except SystemExit as e:
    print('SystemExit', e.code)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68631cb975c88326a066adbbf1675545