### PR TITLE
Use AsyncResolver in aiohttp connector

### DIFF
--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -59,6 +59,7 @@ except ImportError:
     print("📦 Installing aiodns...")
     import subprocess
     subprocess.check_call([sys.executable, "-m", "pip", "install", "aiodns"])
+    import aiodns
 
 # ============================================================================
 # CONFIGURATION & SETTINGS
@@ -919,7 +920,8 @@ class UltimateVPNMerger:
             limit=CONFIG.concurrent_limit,
             limit_per_host=10,
             ttl_dns_cache=300,
-            ssl=ssl.create_default_context()
+            ssl=ssl.create_default_context(),
+            resolver=aiodns.AsyncResolver()
         )
         
         self.fetcher.session = aiohttp.ClientSession(connector=connector)


### PR DESCRIPTION
## Summary
- ensure aiodns import after installation
- pass `resolver=aiodns.AsyncResolver()` when building the TCPConnector

## Testing
- `python -m py_compile vpn_merger.py vpn_retester.py`
- `python vpn_merger.py --help`

------
https://chatgpt.com/codex/tasks/task_e_686329087050832697ffad66f7c6d558