### PR TITLE
Use atomic output files

### DIFF
--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -1150,16 +1150,21 @@ class UltimateVPNMerger:
         
         # Raw text output
         raw_file = output_dir / f"{prefix}vpn_subscription_raw.txt"
-        raw_file.write_text("\n".join(configs), encoding="utf-8")
+        tmp_raw = raw_file.with_suffix('.tmp')
+        tmp_raw.write_text("\n".join(configs), encoding="utf-8")
+        tmp_raw.replace(raw_file)
         
         # Base64 output
         base64_content = base64.b64encode("\n".join(configs).encode("utf-8")).decode("utf-8")
         base64_file = output_dir / f"{prefix}vpn_subscription_base64.txt"
-        base64_file.write_text(base64_content, encoding="utf-8")
+        tmp_base64 = base64_file.with_suffix('.tmp')
+        tmp_base64.write_text(base64_content, encoding="utf-8")
+        tmp_base64.replace(base64_file)
         
         # Enhanced CSV with comprehensive performance data
         csv_file = output_dir / f"{prefix}vpn_detailed.csv"
-        with open(csv_file, 'w', newline='', encoding='utf-8') as f:
+        tmp_csv = csv_file.with_suffix('.tmp')
+        with open(tmp_csv, 'w', newline='', encoding='utf-8') as f:
             writer = csv.writer(f)
             writer.writerow(['Config', 'Protocol', 'Host', 'Port', 'Ping_MS', 'Reachable', 'Source'])
             for result in results:
@@ -1168,6 +1173,7 @@ class UltimateVPNMerger:
                     result.config, result.protocol, result.host, result.port,
                     ping_ms, result.is_reachable, result.source_url
                 ])
+        tmp_csv.replace(csv_file)
         
         # Comprehensive JSON report
         report = {
@@ -1203,7 +1209,9 @@ class UltimateVPNMerger:
         }
         
         report_file = output_dir / f"{prefix}vpn_report.json"
-        report_file.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+        tmp_report = report_file.with_suffix('.tmp')
+        tmp_report.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+        tmp_report.replace(report_file)
     
     def _print_final_summary(self, config_count: int, elapsed_time: float, stats: Dict) -> None:
         """Print comprehensive final summary."""


### PR DESCRIPTION
## Summary
- avoid partially written files by writing to `.tmp` first

## Testing
- `python -m py_compile vpn_merger.py vpn_retester.py`


------
https://chatgpt.com/codex/tasks/task_e_6863290a8c388326b2e0f51f02ccfdb6