### PR TITLE
Introduce jittered backoff for fetch_source

### DIFF
--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -30,6 +30,7 @@ import csv
 import hashlib
 import json
 import logging
+import random
 import re
 import ssl
 import sys
@@ -798,7 +799,8 @@ class AsyncSourceFetcher:
                     
             except Exception:
                 if attempt < CONFIG.max_retries - 1:
-                    await asyncio.sleep(2 ** attempt)
+                    # Use a capped and jittered delay to reduce tail latency
+                    await asyncio.sleep(min(3, 1.5 + random.random()))
                     
         return url, []
 


### PR DESCRIPTION
## Summary
- import `random`
- replace exponential retry delay with capped jittered delay in `fetch_source`

## Testing
- `pip install -r requirements.txt`
- `python vpn_merger.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68632913f49c832693062c12c581b222