### PR TITLE
Fix AsyncResolver usage and set batch defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 | **Availability Testing** | Checks each source before downloading. | Skip dead links and save time. |
 | **Connectivity Testing** | Optional TCP checks measure real latency. | Prioritize servers that actually respond. |
 | **Smart Sorting** | Orders the final list by reachability and speed. | Quickly pick the best server in your VPN client. |
-| **Batch Saving** | Periodically saves intermediate results with `--batch-size`. | Useful on unreliable connections. |
+| **Batch Saving** | Periodically saves intermediate results with `--batch-size` (default `100`). | Useful on unreliable connections. |
 | **Protocol Filtering** | Use `--include-protocols` or `--exclude-protocols` to filter by protocol. | Keep only VLESS servers or drop Shadowsocks, etc. |
 | **TLS Fragment / Top N** | Use `--tls-fragment` or `--top-n` to trim the output. | Obscure SNI or keep only the fastest N entries. |
 | **Resume from File** | `--resume` loads a previous raw/base64 output before fetching. | Continue a crashed run without starting over. |
@@ -54,7 +54,7 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 
 **Batch Saving**
 
-> With `--batch-size` you can periodically save progress. Useful on unstable networks; if the run stops, resume with `--resume` and only new servers will be fetched.
+> With `--batch-size` (default `100`) you can periodically save progress. Useful on unstable networks; if the run stops, resume with `--resume` and only new servers will be fetched.
 
 **Protocol Filtering**
 
@@ -105,7 +105,7 @@ The script automates a simple but powerful process to create the best possible s
 4.  **⚡ Tests Server Performance**: This is the key step. It attempts a direct connection to each individual server to measure its real-world connection speed (latency/ping). Servers that are offline or too slow are discarded.
 5.  **🧹 Cleans and Sorts**: Finally, it removes any duplicate servers and sorts the remaining, working servers from **fastest to slowest**.
 6.  **📦 Generates Outputs**: It saves this final, sorted list into multiple formats, including the `base64` subscription file that you use in your app.
-7.  **📁 Optional Batch Saving**: With `--batch-size`, the script periodically saves intermediate results while it runs.
+7.  **📁 Optional Batch Saving**: With `--batch-size` (default `100`), the script periodically saves intermediate results while it runs.
 
 -----
 
@@ -287,7 +287,7 @@ Here’s how to add your new subscription link to the best **free** applications
 
 Run `python vpn_merger.py --help` to see all options. Important flags include:
 
-  * `--batch-size N` - save intermediate files every `N` configs.
+  * `--batch-size N` - save intermediate files every `N` configs (default `100`, `0` to disable).
   * `--threshold N` - stop once `N` unique configs are collected.
   * `--no-url-test` - skip reachability testing for faster execution.
   * `--no-sort` - keep configs in the order retrieved without sorting.

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -42,6 +42,7 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 from urllib.parse import urlparse
 
 import aiohttp
+from aiohttp.resolver import AsyncResolver
 
 # Event loop compatibility fix
 try:
@@ -128,7 +129,7 @@ CONFIG = Config(
     enable_sorting=True,
     test_timeout=5.0,
     output_dir="output",
-    batch_size=0,
+    batch_size=100,
     threshold=0,
     top_n=0,
     tls_fragment=None,
@@ -958,7 +959,7 @@ class UltimateVPNMerger:
             limit_per_host=10,
             ttl_dns_cache=300,
             ssl=ssl.create_default_context(),
-            resolver=aiodns.AsyncResolver()
+            resolver=AsyncResolver()
         )
         
         self.fetcher.session = aiohttp.ClientSession(connector=connector)
@@ -1330,8 +1331,12 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(description="VPN Merger")
-    parser.add_argument("--batch-size", type=int, default=CONFIG.batch_size,
-                        help="Save intermediate output every N configs (0 to disable)")
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=CONFIG.batch_size,
+        help="Save intermediate output every N configs (0 disables, default 100)"
+    )
     parser.add_argument("--threshold", type=int, default=CONFIG.threshold,
                         help="Stop processing after N unique configs (0 = unlimited)")
     parser.add_argument("--top-n", type=int, default=CONFIG.top_n,


### PR DESCRIPTION
## Summary
- use `AsyncResolver` from `aiohttp.resolver` for the TCP connector
- enable batch saving by default (100 configs)
- document the new default in the README

## Testing
- `python -m py_compile vpn_merger.py vpn_retester.py`

------
https://chatgpt.com/codex/tasks/task_e_6863312434588326a239a12d7c20557b