### PR TITLE
Add batch controls and singbox output

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 2. Run `pip install -r requirements.txt` in the project folder.
 3. Execute `python vpn_merger.py` and wait for the `output` directory.
 4. *(Optional)* pass extra flags like `--max-ping 200` or `--concurrent-limit 10` to suit your connection.
-5. Import the `output/vpn_subscription_base64.txt` link into your VPN app.
+5. Import the `output/vpn_subscription_base64.txt` link into your VPN app or load `vpn_singbox.json` in clients like sing-box.
 
 ## ✨ Key Features & Use Cases
 
@@ -33,6 +33,10 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 | **Max Ping Filter** | Remove configs with latency above `--max-ping` ms. | Keep only fast servers for gaming or streaming. |
 | **Concurrent Limit / Retries** | Tweak network load with `--concurrent-limit` and `--max-retries`. | Prevent crashes on slow networks or strict hosts. |
 | **Logging to File** | Save all output to a file with `--log-file`. | Useful for headless servers or debugging. |
+| **Standalone or Cumulative Batches** | Use `--cumulative-batches` to keep growing files, otherwise each batch only contains new configs. | Flexible automation for heavy runs. |
+| **Strict Split** | Batches are strictly capped at `--batch-size` by default. Add `--no-strict-batch` to simply trigger on size. | Control how incremental files are produced. |
+| **Shuffle Sources** | `--shuffle-sources` randomizes the source order. | Helpful when using `--threshold` to avoid bias. |
+| **Sing-box JSON Output** | Every batch also produces `vpn_singbox.json`. | Import directly into modern clients like sing-box/Stash. |
 
 ### 🔍 Feature Breakdown
 
@@ -278,8 +282,11 @@ Here’s how to add your new subscription link to the best **free** applications
 | `vpn_subscription_raw.txt`    | A plain text list of all the VPN configuration links.                                                    |
 | `vpn_detailed.csv`            | A spreadsheet with detailed info about each server, including protocol, host, and ping time.             |
 | `vpn_report.json`             | A detailed report with all stats and configurations in a developer-friendly format.                      |
+| `vpn_singbox.json`            | Outbound objects ready for import into sing-box/Stash.                                                   |
 
 -----
+
+During long runs, files prefixed with `cumulative_` mirror the latest results and are overwritten at each batch. Use these if you need up-to-the-minute progress.
 
 ## ⚙️ Advanced Usage & Troubleshooting
 
@@ -298,6 +305,9 @@ Run `python vpn_merger.py --help` to see all options. Important flags include:
   * `--resume FILE` - load a previous output file before fetching new sources.
   * `--output-dir DIR` - specify where output files are stored.
   * `--test-timeout SEC` - adjust connection test timeout.
+  * `--cumulative-batches` - make each batch cumulative instead of standalone.
+  * `--no-strict-batch` - don't split strictly by `--batch-size`, just trigger when exceeded.
+  * `--shuffle-sources` - randomize source processing order.
 
 TLS fragments help obscure the real Server Name Indication (SNI) of each
 connection by splitting the handshake into pieces. This makes it harder for


### PR DESCRIPTION
## Summary
- allow choosing cumulative or standalone batches
- support strict or loose splitting behavior
- optional source shuffling
- export sing-box style JSON file per batch
- document new features and usage

## Testing
- `python -m py_compile vpn_merger.py vpn_retester.py`
- `python vpn_merger.py --help` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_686423b462f08326a1d943af6e466530