### PR TITLE
Drop unknown protocols by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 | **Connectivity Testing** | Optional TCP checks measure real latency. | Prioritize servers that actually respond. |
 | **Smart Sorting** | Orders the final list by reachability and speed. | Quickly pick the best server in your VPN client. |
 | **Batch Saving** | Periodically saves intermediate results with `--batch-size` (default `100`). | Useful on unreliable connections. |
-| **Protocol Filtering** | Use `--include-protocols` or `--exclude-protocols` to filter by protocol. | Keep only VLESS servers or drop Shadowsocks, etc. |
+| **Protocol Filtering** | Use `--include-protocols` or `--exclude-protocols` to filter by protocol (defaults to dropping `OTHER`). | Keep only VLESS servers or drop Shadowsocks, etc. |
 | **TLS Fragment / Top N** | Use `--tls-fragment` or `--top-n` to trim the output. | Obscure SNI or keep only the fastest N entries. |
 | **Resume from File** | `--resume` loads a previous raw/base64 output before fetching. | Continue a crashed run without starting over. |
 | **Custom Output Dir** | Use `--output-dir` to choose where files are saved. | Organize results anywhere you like. |
@@ -62,7 +62,7 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 
 **Protocol Filtering**
 
-> Use `--include-protocols` or `--exclude-protocols` to keep only certain technologies (e.g. just Reality) or remove unwanted ones (like Shadowsocks). Combine with `--tls-fragment` or `--top-n` for even finer control.
+> Use `--include-protocols` or `--exclude-protocols` to keep only certain technologies (e.g. just Reality) or remove unwanted ones (like Shadowsocks). By default the scripts remove any config detected as `Other`. Combine with `--tls-fragment` or `--top-n` for even finer control.
 
 **Resume from File**
 
@@ -286,6 +286,24 @@ Here’s how to add your new subscription link to the best **free** applications
 
 -----
 
+### 🔑 Protocol Types and Defaults
+
+Each server link is classified into a protocol type. The merger knows these main kinds:
+
+- **VLESS** – modern V2Ray replacement with great compatibility.
+- **VMess** – classic protocol, still widely used but easier to detect.
+- **Reality** – secure handshake extension of VLESS.
+- **Hysteria2**/**Hysteria** – UDP based for speed with built‑in obfuscation.
+- **TUIC** – another fast UDP protocol.
+- **Trojan** – looks like normal HTTPS traffic.
+- **Shadowsocks** – lightweight and supported almost everywhere.
+- **Naive**, **Juicity**, **WireGuard**, **ShadowTLS**, **Brook** – niche options with special features.
+- **Other** – anything that doesn't match the above (often plain SOCKS/HTTP proxies or experimental formats).
+
+`Other` entries are usually less stable or lack encryption, so both scripts drop them by default. Pass `--exclude-protocols ""` to keep everything or supply your own list.
+
+-----
+
 During long runs, files prefixed with `cumulative_` mirror the latest results and are overwritten at each batch. Use these if you need up-to-the-minute progress.
 
 ## ⚙️ Advanced Usage & Troubleshooting
@@ -301,7 +319,7 @@ Run `python vpn_merger.py --help` to see all options. Important flags include:
   * `--top-n N` - keep only the best `N` configs after sorting.
   * `--tls-fragment TEXT` - only keep configs containing this TLS fragment.
   * `--include-protocols LIST` - comma-separated protocols to include (e.g. `VLESS,Reality`).
-  * `--exclude-protocols LIST` - comma-separated protocols to exclude.
+  * `--exclude-protocols LIST` - protocols to drop. By default `OTHER` is excluded; pass an empty string to keep everything.
   * `--resume FILE` - load a previous output file before fetching new sources.
   * `--output-dir DIR` - specify where output files are stored.
   * `--test-timeout SEC` - adjust connection test timeout.
@@ -330,7 +348,7 @@ If you already generated a subscription file, run `python vpn_retester.py <path>
 * `--concurrent-limit` limit how many tests run in parallel
 * `--test-timeout` set the connection timeout in seconds
 * `--max-ping` drop configs slower than this ping (ms)
-* `--include-protocols` or `--exclude-protocols` filter by protocol
+* `--include-protocols` or `--exclude-protocols` filter by protocol (default drops `OTHER`)
 * `--output-dir` choose where results are written
 * `--no-base64` / `--no-csv` disable those outputs
 

--- a/vpn_retester.py
+++ b/vpn_retester.py
@@ -101,8 +101,12 @@ def main() -> None:
                         help="Discard configs slower than this ping in ms (0 disables)")
     parser.add_argument("--include-protocols", type=str, default=None,
                         help="Comma-separated protocols to include")
-    parser.add_argument("--exclude-protocols", type=str, default=None,
-                        help="Comma-separated protocols to exclude")
+    parser.add_argument(
+        "--exclude-protocols",
+        type=str,
+        default=None,
+        help="Comma-separated protocols to exclude (default: OTHER)"
+    )
     parser.add_argument("--output-dir", type=str, default=CONFIG.output_dir,
                         help="Directory to save output files")
     parser.add_argument("--no-base64", action="store_true", help="Do not save base64 file")
@@ -114,8 +118,14 @@ def main() -> None:
     CONFIG.max_ping_ms = args.max_ping if args.max_ping > 0 else None
     if args.include_protocols:
         CONFIG.include_protocols = {p.strip().upper() for p in args.include_protocols.split(',') if p.strip()}
-    if args.exclude_protocols:
-        CONFIG.exclude_protocols = {p.strip().upper() for p in args.exclude_protocols.split(',') if p.strip()}
+    if args.exclude_protocols is None:
+        CONFIG.exclude_protocols = {"OTHER"}
+    elif args.exclude_protocols.strip() == "":
+        CONFIG.exclude_protocols = None
+    else:
+        CONFIG.exclude_protocols = {
+            p.strip().upper() for p in args.exclude_protocols.split(',') if p.strip()
+        }
     CONFIG.output_dir = str(Path(args.output_dir).expanduser())
     CONFIG.write_base64 = not args.no_base64
     CONFIG.write_csv = not args.no_csv


### PR DESCRIPTION
## Summary
- filter out `Other` protocol entries by default
- add matching control to `vpn_retester`
- document protocol types and the new default

## Testing
- `python -m py_compile vpn_merger.py vpn_retester.py`

------
https://chatgpt.com/codex/tasks/task_e_686576c4b0e08326be4b6dc6cf78ecec