### PR TITLE
Set Hiddify protocol defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Welcome to the VPN Subscription Merger! This project provides a powerful Python 
 
 This guide is designed for **everyone**, from absolute beginners with no coding experience to advanced users who want full automation.
 
+> **Note**: The default protocol list is optimised for the Hiddify client. Other VPN apps may require adjusting `--include-protocols`.
+
 ### ⚡ Quick Start
 
 1. Install **Python 3.8+** and clone this repository.
@@ -24,7 +26,7 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 | **Connectivity Testing** | Optional TCP checks measure real latency. | Prioritize servers that actually respond. |
 | **Smart Sorting** | Orders the final list by reachability and speed. | Quickly pick the best server in your VPN client. |
 | **Batch Saving** | Periodically saves intermediate results with `--batch-size` (default `100`). | Useful on unreliable connections. |
-| **Protocol Filtering** | Use `--include-protocols` or `--exclude-protocols` to filter by protocol (defaults to dropping `OTHER`). | Keep only VLESS servers or drop Shadowsocks, etc. |
+| **Protocol Filtering** | Use `--include-protocols` or `--exclude-protocols` to filter by protocol (defaults to the Hiddify list). | Keep only the protocols your client supports. |
 | **TLS Fragment / Top N** | Use `--tls-fragment` or `--top-n` to trim the output. | Obscure SNI or keep only the fastest N entries. |
 | **Resume from File** | `--resume` loads a previous raw/base64 output before fetching. | Continue a crashed run without starting over. |
 | **Custom Output Dir** | Use `--output-dir` to choose where files are saved. | Organize results anywhere you like. |
@@ -37,6 +39,7 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 | **Strict Split** | Batches are strictly capped at `--batch-size` by default. Add `--no-strict-batch` to simply trigger on size. | Control how incremental files are produced. |
 | **Shuffle Sources** | `--shuffle-sources` randomizes the source order. | Helpful when using `--threshold` to avoid bias. |
 | **Sing-box JSON Output** | Every batch also produces `vpn_singbox.json`. | Import directly into modern clients like sing-box/Stash. |
+| **Hiddify Optimised** | Default protocols match the Hiddify client. | Other clients may reject some entries. |
 
 ### 🔍 Feature Breakdown
 
@@ -288,19 +291,23 @@ Here’s how to add your new subscription link to the best **free** applications
 
 ### 🔑 Protocol Types and Defaults
 
-Each server link is classified into a protocol type. The merger knows these main kinds:
+Each server link is classified into a protocol type. By default the merger only keeps the following protocols, optimised for the Hiddify client:
 
-- **VLESS** – modern V2Ray replacement with great compatibility.
-- **VMess** – classic protocol, still widely used but easier to detect.
-- **Reality** – secure handshake extension of VLESS.
-- **Hysteria2**/**Hysteria** – UDP based for speed with built‑in obfuscation.
-- **TUIC** – another fast UDP protocol.
-- **Trojan** – looks like normal HTTPS traffic.
-- **Shadowsocks** – lightweight and supported almost everywhere.
-- **Naive**, **Juicity**, **WireGuard**, **ShadowTLS**, **Brook** – niche options with special features.
-- **Other** – anything that doesn't match the above (often plain SOCKS/HTTP proxies or experimental formats).
+- **Proxy** (HTTP/SOCKS)
+- **Shadowsocks**
+- **Clash** / **ClashMeta**
+- **V2Ray** / **Xray**
+- **Reality**
+- **VMess**
+- **WireGuard**
+- **ECH**
+- **VLESS**
+- **Hysteria** / **Hysteria2**
+- **TUIC**
+- **Sing-box** / **Singbox**
+- **ShadowTLS**
 
-`Other` entries are usually less stable or lack encryption, so both scripts drop them by default. Pass `--exclude-protocols ""` to keep everything or supply your own list.
+Some VPN clients may not recognise every item in this list, and other clients might support additional protocols that are omitted here. Use `--include-protocols` if you need to expand it.
 
 -----
 

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -17,6 +17,7 @@ Features:
 • Multiple output formats (raw, base64, CSV, JSON)
 • Comprehensive error handling and retry logic
 • Best practices implemented throughout
+• Default protocol set optimised for the Hiddify client
 
 Requirements: pip install aiohttp aiodns nest-asyncio
 Author: Final Unified Edition - June 30, 2025
@@ -123,12 +124,12 @@ CONFIG = Config(
     concurrent_limit=50,
     max_configs_per_source=75000,
     valid_prefixes=(
-        "vmess://", "vless://", "ss://", "trojan://", "hy2://", 
-        "hysteria://", "hysteria2://", "tuic://", "reality://", 
-        "naive://", "juicity://", "shadowtls://", "wireguard://", 
-        "brook://", "socks://", "socks4://", "socks5://",
+        "vmess://", "vless://", "reality://",
+        "ss://", "hy2://", "hysteria://", "hysteria2://",
+        "tuic://", "shadowtls://", "wireguard://",
+        "socks://", "socks4://", "socks5://",
         "http://", "https://", "grpc://", "ws://", "wss://",
-        "ssr://", "tcp://", "kcp://", "quic://", "h2://",
+        "tcp://", "kcp://", "quic://", "h2://",
     ),
     enable_url_testing=True,
     enable_sorting=True,
@@ -138,7 +139,12 @@ CONFIG = Config(
     threshold=0,
     top_n=0,
     tls_fragment=None,
-    include_protocols=None,
+    include_protocols={
+        "PROXY", "SHADOWSOCKS", "CLASH", "V2RAY", "REALITY",
+        "VMESS", "XRAY", "WIREGUARD", "ECH", "VLESS",
+        "HYSTERIA", "TUIC", "SING-BOX", "SINGBOX",
+        "SHADOWTLS", "CLASHMETA", "HYSTERIA2",
+    },
     exclude_protocols={"OTHER"},
     resume_file=None,
     max_ping_ms=1000,


### PR DESCRIPTION
## Summary
- restrict `valid_prefixes` and set `include_protocols` to Hiddify's protocol list
- document the Hiddify optimization in README and script
- describe allowed protocols in the README

## Testing
- `python vpn_merger.py --help` *(fails: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6865ad51128083269d5778df3d2af97f